### PR TITLE
ImageDataset doesn't exist in datas.dataset (unused anyway)

### DIFF
--- a/Transformer/inference.py
+++ b/Transformer/inference.py
@@ -7,7 +7,6 @@ import torch
 import matplotlib.pyplot as plt
 import logging
 from utils.util import set_seed
-from datas.dataset import ImageDataset
 from models.model import GPTConfig,GPT
 import argparse
 from utils.util import sample_mask,sample_mask_all


### PR DESCRIPTION
Otherwise I get this error:
```
Traceback (most recent call last):
  File "inference.py", line 10, in <module>
    from datas.dataset import ImageDataset
ImportError: cannot import name 'ImageDataset' from 'datas.dataset' (/content/ICT/Transformer/datas/dataset.py)
```